### PR TITLE
Suppress OpenGL compiler warnings

### DIFF
--- a/CME212/SFML_Viewer.hpp
+++ b/CME212/SFML_Viewer.hpp
@@ -19,6 +19,10 @@
 #include <map>
 #include <numeric>
 
+// Suppress compiler warnings generated from OpenGL deprecation on Mac OS
+#ifdef __APPLE__
+#define GL_SILENCE_DEPRECATION
+#endif
 #include <SFML/Window.hpp>
 #include <SFML/OpenGL.hpp>
 


### PR DESCRIPTION
Make experience better for Mac users by suppressing compiler warnings emanating from OpenGL deprecation on Mac OS.